### PR TITLE
feat: enhance supabase tracking

### DIFF
--- a/core/infrastructure/logging/agent_logger.py
+++ b/core/infrastructure/logging/agent_logger.py
@@ -75,11 +75,13 @@ class LogEntry:
 class AgentLogger:
     """Advanced logger for AI agents and tools interactions."""
     
-    def __init__(self, name: str = "agent_logger"):
+    def __init__(self, name: str = "agent_logger", tracker=None, run_id: Optional[str] = None):
         self.name = name
         self.logger = logging.getLogger(name)
         self.entries: List[LogEntry] = []
         self.active_sessions: Dict[str, Dict[str, Any]] = {}
+        self.tracker = tracker
+        self.run_id = run_id
         
         # Configure detailed formatting
         if not self.logger.handlers:
@@ -90,6 +92,11 @@ class AgentLogger:
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
             self.logger.setLevel(logging.DEBUG)
+
+    def set_tracker(self, tracker, run_id: str) -> None:
+        """Attach Supabase tracker and run identifier."""
+        self.tracker = tracker
+        self.run_id = run_id
     
     def start_agent_session(
         self, 
@@ -198,8 +205,10 @@ class AgentLogger:
                 'next_action': next_action
             }
         )
-        
+
         self._log_entry(entry)
+        if self.tracker and self.run_id:
+            self.tracker.add_log(self.run_id, "THINK", thought, session.get('agent_name'))
     
     def log_tool_call(
         self, 

--- a/core/infrastructure/orchestration/agent_executor.py
+++ b/core/infrastructure/orchestration/agent_executor.py
@@ -164,6 +164,24 @@ class AgentExecutor:
                 final_output=final_response
             )
 
+            tracker = context.get('tracker')
+            run_id = context.get('run_id')
+            step_number = context.get('step_number')
+            if tracker and run_id:
+                try:
+                    tracker.log_agent_execution(
+                        run_id=run_id,
+                        agent_name=agent.name,
+                        step=step_number or 0,
+                        input_data={"task_description": task_description},
+                        output_data={"response": final_response},
+                        tokens=token_usage.total_tokens,
+                        cost=cost_breakdown.total_cost,
+                        duration_seconds=duration_ms / 1000,
+                    )
+                except Exception as e:  # pragma: no cover
+                    logger.warning(f"Tracker log_agent_execution failed: {e}")
+
             return final_response
 
         except Exception as e:

--- a/core/infrastructure/orchestration/task_orchestrator.py
+++ b/core/infrastructure/orchestration/task_orchestrator.py
@@ -28,10 +28,12 @@ class TaskOrchestrator:
         self.executed_tasks: set = set()
     
     async def execute_workflow(
-        self, 
-        workflow: Workflow, 
+        self,
+        workflow: Workflow,
         context: Dict[str, Any] = None,
-        verbose: bool = True
+        verbose: bool = True,
+        run_id: Optional[str] = None,
+        tracker: Any = None,
     ) -> Dict[str, Any]:
         """
         Execute a workflow with all its tasks.
@@ -58,11 +60,16 @@ class TaskOrchestrator:
                 'workflow_name': workflow.name,
                 'client_profile': workflow.client_profile,
                 'target_audience': workflow.target_audience,
-                'context': workflow.context
+                'context': workflow.context,
+                'run_id': run_id,
+                'tracker': tracker,
             })
             
             # Execute tasks in dependency order
+            step_number = 0
             for task in workflow.tasks:
+                step_number += 1
+                execution_context['step_number'] = step_number
                 await self._execute_task(task, execution_context, verbose)
             
             # Mark workflow as completed
@@ -102,9 +109,9 @@ class TaskOrchestrator:
             }
     
     async def _execute_task(
-        self, 
-        task: Task, 
-        context: Dict[str, Any], 
+        self,
+        task: Task,
+        context: Dict[str, Any],
         verbose: bool = True
     ) -> str:
         """

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -68,6 +68,7 @@ CREATE TABLE content_generations (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     client_id UUID REFERENCES clients(id),
     workflow_id UUID REFERENCES workflows(id),
+    run_id UUID,
     title VARCHAR(500),
     content TEXT,
     content_type VARCHAR(50),
@@ -132,6 +133,7 @@ CREATE INDEX idx_content_generations_client_id ON content_generations(client_id)
 CREATE INDEX idx_content_generations_status ON content_generations(status);
 CREATE INDEX idx_content_generations_created_at ON content_generations(created_at DESC);
 CREATE INDEX idx_content_generations_created_by ON content_generations(created_by);
+CREATE INDEX idx_content_generations_run_id ON content_generations(run_id);
 
 -- Clients indexes
 CREATE INDEX idx_clients_name ON clients(name);

--- a/supabase_tracking_schema.sql
+++ b/supabase_tracking_schema.sql
@@ -55,3 +55,17 @@ CREATE INDEX IF NOT EXISTS idx_workflow_runs_started_at ON workflow_runs(started
 CREATE INDEX IF NOT EXISTS idx_agent_executions_run_id ON agent_executions(run_id);
 CREATE INDEX IF NOT EXISTS idx_run_logs_run_id ON run_logs(run_id);
 
+-- =====================================================
+-- RUN DOCUMENTS (RAG usage)
+-- =====================================================
+CREATE TABLE IF NOT EXISTS run_documents (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    client_name VARCHAR(100),
+    document_path TEXT,
+    source_url TEXT,
+    retrieved_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_documents_run_id ON run_documents(run_id);
+

--- a/tests/test_agent_logger_tracking.py
+++ b/tests/test_agent_logger_tracking.py
@@ -1,0 +1,12 @@
+import pytest
+from unittest.mock import Mock
+
+from core.infrastructure.logging.agent_logger import AgentLogger
+
+
+def test_agent_logger_thinking_saved_to_tracker():
+    tracker = Mock()
+    logger = AgentLogger(tracker=tracker, run_id="run1")
+    session_id = logger.start_agent_session("a1", "agent", "t1", "run1", "desc")
+    logger.log_agent_thinking(session_id, "thought")
+    tracker.add_log.assert_called_once_with("run1", "THINK", "thought", "agent")

--- a/tests/test_supabase_tracker_methods.py
+++ b/tests/test_supabase_tracker_methods.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+
+from core.infrastructure.database.supabase_tracker import SupabaseTracker
+
+
+def _mock_tracker():
+    tracker = SupabaseTracker.__new__(SupabaseTracker)
+    tracker.client = Mock()
+    tracker.client.table.return_value.insert.return_value.execute.return_value = None
+    return tracker
+
+
+def test_log_rag_document_calls_supabase():
+    tracker = _mock_tracker()
+    tracker.log_rag_document("run1", "client", "doc.md", None)
+    tracker.client.table.assert_called_with("run_documents")
+    tracker.client.table.return_value.insert.assert_called()
+
+
+def test_save_run_content_calls_supabase():
+    tracker = _mock_tracker()
+    tracker.save_run_content("run1", "client", "workflow", "title", "body", {"a":1})
+    tracker.client.table.assert_called_with("content_generations")
+    tracker.client.table.return_value.insert.assert_called()


### PR DESCRIPTION
## Summary
- track RAG document usage and save run content in Supabase
- persist agent "thinking" logs and agent execution metrics with run/workflow context
- expose run document history and workflow filters in tracking CLI

## Testing
- `pytest tests/test_agent_logger_tracking.py tests/test_supabase_tracker_methods.py`

------
https://chatgpt.com/codex/tasks/task_e_68b626b653e88327a7047af5f2ac265e