### PR TITLE
feat: externalize configuration defaults

### DIFF
--- a/api/rest/main.py
+++ b/api/rest/main.py
@@ -51,7 +51,7 @@ def create_app() -> FastAPI:
     # Add CORS middleware
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"] if settings.is_development() else ["http://localhost:3000"],
+        allow_origins=settings.cors_allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/core/infrastructure/workflows/handlers/premium_newsletter_handler.py
+++ b/core/infrastructure/workflows/handlers/premium_newsletter_handler.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, List
 
 from ..base.workflow_base import WorkflowHandler
 from ..registry import register_workflow
+from core.infrastructure.config.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -39,14 +40,14 @@ class PremiumNewsletterHandler(WorkflowHandler):
 
         # Premium sources are optional - provide defaults if none specified
         if not sources or len(sources) < 1:
-            # Use default premium sources for testing/demo purposes
-            sources = [
-                'https://www.bloomberg.com',
-                'https://www.reuters.com',
-                'https://www.wsj.com'
-            ]
-            context['premium_sources'] = sources
-            logger.info(f"🔧 Using default premium sources: {len(sources)} sources")
+            settings = get_settings()
+            default_sources = settings.premium_default_sources
+            if default_sources:
+                sources = default_sources
+                context['premium_sources'] = sources
+                logger.info(
+                    f"🔧 Using default premium sources: {len(sources)} sources"
+                )
 
         if len(sources) > 10:
             raise ValueError("Maximum 10 premium sources allowed")

--- a/web/react-app/public/index.html
+++ b/web/react-app/public/index.html
@@ -9,8 +9,8 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     
-    <!-- Preconnect to API -->
-    <link rel="preconnect" href="http://localhost:8001" />
+    <!-- Preconnect to API; URL injected via REACT_APP_API_URL at build time -->
+    <link rel="preconnect" href="%REACT_APP_API_URL%" />
     
     <title>CGSRef - Content Generation System</title>
   </head>

--- a/web/react-app/src/config/api.ts
+++ b/web/react-app/src/config/api.ts
@@ -1,5 +1,8 @@
 // API Configuration
-export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+if (!process.env.REACT_APP_API_URL) {
+  throw new Error('REACT_APP_API_URL is not defined');
+}
+export const API_BASE_URL = process.env.REACT_APP_API_URL as string;
 
 export const API_ENDPOINTS = {
   BASE: API_BASE_URL,


### PR DESCRIPTION
## Summary
- require external `SECRET_KEY` and configurable CORS origins
- allow CLI provider/model selection and move premium source defaults to settings
- parameterize frontend API URL and preconnect link

## Testing
- `SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b840e817fc8327a7e02ff8b35c7fdb