### PR TITLE
feat: add model token limits and selector

### DIFF
--- a/core/application/interfaces/llm_provider_interface.py
+++ b/core/application/interfaces/llm_provider_interface.py
@@ -135,15 +135,15 @@ class LLMProviderInterface(ABC):
         pass
     
     @abstractmethod
-    async def get_available_models(self, config: ProviderConfig) -> List[str]:
+    async def get_available_models(self, config: ProviderConfig) -> List[Dict[str, Any]]:
         """
-        Get list of available models for the provider.
-        
+        Get list of available models for the provider with metadata.
+
         Args:
             config: Provider configuration
-            
+
         Returns:
-            List of available model names
+            List of model information dictionaries
         """
         pass
     

--- a/core/domain/value_objects/provider_config.py
+++ b/core/domain/value_objects/provider_config.py
@@ -1,7 +1,7 @@
 """Provider configuration value object."""
 
 from dataclasses import dataclass
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 from enum import Enum
 
 
@@ -71,49 +71,50 @@ class ProviderConfig:
         }
         return defaults.get(self.provider, "gpt-4o")
     
-    def get_available_models(self) -> list[str]:
-        """Get list of available models for the provider."""
-        models = {
+    def get_available_models(self) -> List[Dict[str, Any]]:
+        """Get list of available models for the provider with token limits."""
+        models: Dict[LLMProvider, List[Dict[str, Any]]] = {
             LLMProvider.OPENAI: [
-                "gpt-3.5-turbo",
-                "gpt-4",
-                "gpt-4-turbo",
-                "gpt-4o",
-                "gpt-4o-mini",
-                "o1",
-                "o1-mini",
-                "o1-pro",
-                "o3-mini"
+                {"name": "gpt-3.5-turbo", "max_tokens": 16000},
+                {"name": "gpt-4", "max_tokens": 8000},
+                {"name": "gpt-4-turbo", "max_tokens": 128000},
+                {"name": "gpt-4o", "max_tokens": 128000},
+                {"name": "gpt-4o-mini", "max_tokens": 128000},
+                {"name": "gpt-5", "max_tokens": 200000},
+                {"name": "o1", "max_tokens": 200000},
+                {"name": "o1-mini", "max_tokens": 200000},
+                {"name": "o1-pro", "max_tokens": 200000},
+                {"name": "o3-mini", "max_tokens": 200000},
             ],
             LLMProvider.ANTHROPIC: [
-                "claude-3-5-haiku-20241022",
-                "claude-3-5-haiku-latest",
-                "claude-3-7-sonnet-20250219",
-                "claude-3-7-sonnet-latest",
-                "claude-sonnet-4-20250514",
-                "claude-opus-4-20250514"
+                {"name": "claude-3-5-haiku-20241022", "max_tokens": 200000},
+                {"name": "claude-3-5-haiku-latest", "max_tokens": 200000},
+                {"name": "claude-3-7-sonnet-20250219", "max_tokens": 200000},
+                {"name": "claude-3-7-sonnet-latest", "max_tokens": 200000},
+                {"name": "claude-sonnet-4-20250514", "max_tokens": 200000},
+                {"name": "claude-opus-4-20250514", "max_tokens": 200000},
             ],
             LLMProvider.DEEPSEEK: [
-                "deepseek-chat",
-                "deepseek-coder"
+                {"name": "deepseek-chat", "max_tokens": 64000},
+                {"name": "deepseek-coder", "max_tokens": 64000},
             ],
             LLMProvider.GEMINI: [
-                "gemini-2.5-pro",
-                "gemini-2.5-flash",
-                "gemini-2.5-flash-lite",
-                "gemini-2.5-flash-live",
-                "gemini-1.5-pro",
-                "gemini-1.5-flash",
-                "gemini-pro",
-                "gemini-1.5-pro-latest",
-                "gemini-1.5-flash-latest"
-            ]
+                {"name": "gemini-2.5-pro", "max_tokens": 1000000},
+                {"name": "gemini-2.5-flash", "max_tokens": 1000000},
+                {"name": "gemini-2.5-flash-lite", "max_tokens": 1000000},
+                {"name": "gemini-2.5-flash-live", "max_tokens": 1000000},
+                {"name": "gemini-1.5-pro", "max_tokens": 1000000},
+                {"name": "gemini-1.5-flash", "max_tokens": 1000000},
+                {"name": "gemini-pro", "max_tokens": 1000000},
+                {"name": "gemini-1.5-pro-latest", "max_tokens": 1000000},
+                {"name": "gemini-1.5-flash-latest", "max_tokens": 1000000},
+            ],
         }
         return models.get(self.provider, [])
     
     def is_model_available(self) -> bool:
         """Check if the configured model is available for the provider."""
-        return self.model in self.get_available_models()
+        return any(m["name"] == self.model for m in self.get_available_models())
     
     def with_temperature(self, temperature: float) -> "ProviderConfig":
         """Create a new config with different temperature."""

--- a/core/infrastructure/external_services/anthropic_adapter.py
+++ b/core/infrastructure/external_services/anthropic_adapter.py
@@ -285,19 +285,18 @@ class AnthropicAdapter(LLMProviderInterface):
             logger.debug(f"Anthropic config validation failed: {str(e)}")
             return False
     
-    async def get_available_models(self, config: ProviderConfig) -> List[str]:
-        """Get available Anthropic models."""
+    async def get_available_models(self, config: ProviderConfig) -> List[Dict[str, Any]]:
+        """Get available Anthropic models with token limits."""
         try:
-            # For now, return the predefined list
-            # In the future, this could make an API call to get real-time model availability
+            # For now, return the predefined list from config
             return config.get_available_models()
         except Exception:
-            # Return default models if API call fails
+            # Fallback to a basic static list
             return [
-                "claude-3-5-haiku-latest",
-                "claude-3-7-sonnet-latest",
-                "claude-sonnet-4-20250514",
-                "claude-opus-4-20250514"
+                {"name": "claude-3-5-haiku-latest", "max_tokens": 200000},
+                {"name": "claude-3-7-sonnet-latest", "max_tokens": 200000},
+                {"name": "claude-sonnet-4-20250514", "max_tokens": 200000},
+                {"name": "claude-opus-4-20250514", "max_tokens": 200000},
             ]
 
     async def estimate_tokens(self, text: str, model: str) -> int:

--- a/test_gemini_25_models.py
+++ b/test_gemini_25_models.py
@@ -31,22 +31,22 @@ async def test_gemini_25_models():
     print("\n2. Testing available models...")
     try:
         config = ProviderConfig.create_gemini_config()
-        models = config.get_available_models()
+        models = [m["name"] for m in config.get_available_models()]
         print(f"   ✅ Total models available: {len(models)}")
-        
+
         gemini_25_models = [
             "gemini-2.5-pro",
-            "gemini-2.5-flash", 
+            "gemini-2.5-flash",
             "gemini-2.5-flash-lite",
             "gemini-2.5-flash-live"
         ]
-        
+
         for model in gemini_25_models:
             if model in models:
                 print(f"   ✅ {model}: Available")
             else:
                 print(f"   ❌ {model}: Missing")
-                
+
         print(f"   ✅ All models: {models}")
         
     except Exception as e:

--- a/test_gemini_integration.py
+++ b/test_gemini_integration.py
@@ -128,7 +128,7 @@ async def test_gemini_integration():
     print("\n10. Testing available models...")
     try:
         models = await provider.get_available_models(config)
-        print(f"   ✅ Available models: {models[:3]}...")  # Show first 3
+        print(f"   ✅ Available models: {[m['name'] for m in models][:3]}...")  # Show first 3 names
 
     except Exception as e:
         print(f"   ❌ Models fetch failed: {e}")

--- a/web/react-app/src/components/WorkflowForm.tsx
+++ b/web/react-app/src/components/WorkflowForm.tsx
@@ -217,6 +217,7 @@ const WorkflowForm: React.FC<WorkflowFormProps> = ({
   const [selectedRAGContents, setSelectedRAGContents] = useState<string[]>([]);
   const [selectedProvider, setSelectedProvider] = useState<string>('openai');
   const [selectedModel, setSelectedModel] = useState<string>('gpt-4o');
+  const [selectedTokens, setSelectedTokens] = useState<number>(4096);
 
   // Determine schema based on workflow
   const getValidationSchema = () => {
@@ -238,6 +239,7 @@ const WorkflowForm: React.FC<WorkflowFormProps> = ({
     formState: { errors, isValid },
     reset,
     watch,
+    setValue,
   } = useForm<any>({
     resolver: yupResolver(getValidationSchema()),
     mode: 'onChange',
@@ -249,6 +251,7 @@ const WorkflowForm: React.FC<WorkflowFormProps> = ({
       provider: selectedProvider,
       model: selectedModel,
       temperature: 0.7,
+      max_tokens: selectedTokens,
     };
 
     if (selectedWorkflow?.id === 'enhanced_article') {
@@ -302,6 +305,11 @@ const WorkflowForm: React.FC<WorkflowFormProps> = ({
   useEffect(() => {
     reset(getDefaultValues());
   }, [selectedWorkflow, selectedClient, reset]);
+
+  // Keep form max_tokens in sync with selectedTokens
+  useEffect(() => {
+    setValue('max_tokens', selectedTokens);
+  }, [selectedTokens, setValue]);
 
   const onSubmit = async (data: any) => {
     if (!selectedClient || !selectedWorkflow) {
@@ -989,8 +997,10 @@ const WorkflowForm: React.FC<WorkflowFormProps> = ({
         control={control}
         selectedProvider={selectedProvider}
         selectedModel={selectedModel}
+        selectedTokens={selectedTokens}
         onProviderChange={setSelectedProvider}
         onModelChange={setSelectedModel}
+        onTokensChange={setSelectedTokens}
       />
 
       {/* RAG Content Selection */}

--- a/web/react-app/src/types/index.ts
+++ b/web/react-app/src/types/index.ts
@@ -58,8 +58,13 @@ export interface GenerationRequest {
 export interface ProviderInfo {
   name: string;
   available: boolean;
-  models: string[];
+  models: ModelInfo[];
   default_model: string;
+}
+
+export interface ModelInfo {
+  name: string;
+  max_tokens: number;
 }
 
 export interface ProvidersResponse {


### PR DESCRIPTION
## Summary
- include max token metadata for each model and expose through providers API
- add token limit selection in ProviderSelector with preset percentage options
- omit temperature parameter for OpenAI reasoning models that don't support it

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3404752608327bf08cf552265fd92