### PR TITLE
feat: dynamic token caps and limits endpoint

### DIFF
--- a/core/application/use_cases/generate_content.py
+++ b/core/application/use_cases/generate_content.py
@@ -187,7 +187,10 @@ class GenerateContentUseCase:
                     "client_profile": request.client_profile,
                     "provider": request.provider_config.provider.value if request.provider_config else None,
                     "dynamic_workflow": True,
-                    "workflow_summary": workflow_result.get('workflow_summary', {})
+                    "workflow_summary": workflow_result.get('workflow_summary', {}),
+                    "prompt_tokens": context.get('prompt_tokens'),
+                    "effective_max_tokens": context.get('effective_max_tokens'),
+                    "model_output_limit": context.get('model_output_limit')
                 }
             )
 


### PR DESCRIPTION
## Summary
- cap completion tokens dynamically based on prompt size and model limits
- surface prompt token metadata in content generation responses
- add `/api/v1/content/limits` endpoint for token availability preview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7249f24788327bfa79c322865487e