### PR TITLE
feat: introduce layered system prompt builder and context pipeline

### DIFF
--- a/core/infrastructure/config/settings.py
+++ b/core/infrastructure/config/settings.py
@@ -92,6 +92,22 @@ class Settings(BaseSettings):
     default_temperature: float = Field(default=0.7, env="DEFAULT_TEMPERATURE")
     max_tokens: Optional[int] = Field(default=None, env="MAX_TOKENS")
 
+    # Prompt orchestration flags
+    use_system_prompt_builder_v2: bool = Field(
+        default=False, env="USE_SYSTEM_PROMPT_BUILDER_V2"
+    )
+    system_prompt_version: str = Field(
+        default="v1", env="SYSTEM_PROMPT_VERSION"
+    )
+
+    # Context pipeline configuration
+    use_context_pipeline_v1: bool = Field(
+        default=False, env="USE_CONTEXT_PIPELINE_V1"
+    )
+    use_context_pipeline_summarize: bool = Field(
+        default=False, env="USE_CONTEXT_PIPELINE_SUMMARIZE"
+    )
+
     # Workflow settings
     workflow_timeout_seconds: int = Field(default=600, env="WORKFLOW_TIMEOUT_SECONDS")  # 10 minutes for complex workflows
     max_retries: int = Field(default=3, env="MAX_RETRIES")

--- a/core/infrastructure/logging/agent_logger.py
+++ b/core/infrastructure/logging/agent_logger.py
@@ -311,17 +311,19 @@ class AgentLogger:
         self._log_entry(entry)
     
     def log_llm_request(
-        self, 
-        session_id: str, 
-        provider: str, 
-        model: str, 
+        self,
+        session_id: str,
+        provider: str,
+        model: str,
         prompt: str,
-        system_message: str = ""
+        system_message: str = "",
+        system_prompt_version: Optional[str] = None,
+        system_prompt_budget: Optional[Dict[str, Any]] = None
     ) -> str:
         """Log an LLM request."""
         request_id = str(uuid4())
         session = self.active_sessions.get(session_id, {})
-        
+
         if session_id in self.active_sessions:
             self.active_sessions[session_id]['llm_calls'] += 1
         
@@ -345,7 +347,12 @@ class AgentLogger:
                 'call_number': session.get('llm_calls', 0)
             }
         )
-        
+
+        if system_prompt_version:
+            entry.data['system_prompt_version'] = system_prompt_version
+        if system_prompt_budget:
+            entry.data['system_prompt_budget'] = system_prompt_budget
+
         self._log_entry(entry)
         return request_id
     

--- a/core/infrastructure/orchestration/context_pipeline.py
+++ b/core/infrastructure/orchestration/context_pipeline.py
@@ -1,0 +1,207 @@
+"""Context compaction pipeline for workflow prompts."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from ..config.settings import Settings, get_settings
+from .token_utils import SimpleTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+KB_PATTERNS = (
+    "rag",
+    "research",
+    "analysis",
+    "context",
+    "brief",
+    "summary",
+    "content",
+    "insight",
+)
+
+RUNTIME_FIELDS = (
+    "topic",
+    "target_audience",
+    "target_word_count",
+    "tone",
+    "edition_number",
+    "include_sources",
+    "custom_instructions",
+    "client_profile",
+    "client_name",
+)
+
+
+SECTION_BUDGETS = {
+    "kb_summary": 1200,
+    "runtime_context": 400,
+    "examples": 400,
+}
+
+
+@dataclass
+class PipelineSection:
+    """Container for intermediate pipeline data."""
+
+    text: str
+    tokens: int
+
+
+class ContextPipeline:
+    """Stage 1 context pipeline with dedupe/normalize/cap operations."""
+
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        tokenizer: Optional[SimpleTokenizer] = None,
+    ) -> None:
+        self.settings = settings or get_settings()
+        self.tokenizer = tokenizer or SimpleTokenizer()
+
+    def build(self, enhanced_context: Dict[str, Any]) -> Dict[str, Any]:
+        start = time.time()
+
+        collected = self._collect(enhanced_context)
+        deduped = {name: self._dedupe_text(text) for name, text in collected.items()}
+        normalized = {name: self._normalize_text(text) for name, text in deduped.items()}
+        capped = {
+            name: self._apply_cap(name, text)
+            for name, text in normalized.items()
+        }
+
+        citations = self._extract_citations(enhanced_context)
+
+        duration_ms = (time.time() - start) * 1000
+        drop_ratios = self._compute_drop_ratios(collected, capped)
+
+        report = {
+            "duration_ms": duration_ms,
+            "drop_ratios": drop_ratios,
+            "budgets": SECTION_BUDGETS,
+            "total_tokens": sum(section.tokens for section in capped.values()),
+        }
+
+        logger.debug(
+            "Context pipeline completed in %.2f ms (tokens=%s)",
+            duration_ms,
+            {name: section.tokens for name, section in capped.items()},
+        )
+
+        return {
+            "kb_summary": capped["kb_summary"].text,
+            "runtime_context": capped["runtime_context"].text,
+            "examples": capped["examples"].text,
+            "citations": citations,
+            "notes": report,
+        }
+
+    # ------------------------------------------------------------------
+    # Stage helpers
+    # ------------------------------------------------------------------
+    def _collect(self, context: Dict[str, Any]) -> Dict[str, str]:
+        kb_chunks: List[str] = []
+        runtime_lines: List[str] = []
+        example_chunks: List[str] = []
+
+        for key in sorted(context.keys()):
+            value = context[key]
+            if not value:
+                continue
+            if isinstance(value, (list, tuple)):
+                str_value = "\n".join(str(item) for item in value if item)
+            else:
+                str_value = str(value)
+
+            lowered_key = key.lower()
+
+            if any(pattern in lowered_key for pattern in KB_PATTERNS):
+                kb_chunks.append(f"[{key}]\n{str_value.strip()}")
+                continue
+
+            if lowered_key.endswith("_examples") or "example" in lowered_key:
+                example_chunks.append(str_value.strip())
+                continue
+
+        for field in RUNTIME_FIELDS:
+            if field in context and context[field]:
+                runtime_lines.append(
+                    f"{field.replace('_', ' ').title()}: {self._inline_value(context[field])}"
+                )
+
+        return {
+            "kb_summary": "\n\n".join(chunk for chunk in kb_chunks if chunk).strip(),
+            "runtime_context": "\n".join(f"- {line}" for line in runtime_lines if line).strip(),
+            "examples": "\n\n".join(chunk for chunk in example_chunks if chunk).strip(),
+        }
+
+    def _dedupe_text(self, text: str) -> str:
+        if not text:
+            return ""
+        seen = set()
+        deduped_lines: List[str] = []
+        for line in text.splitlines():
+            key = line.strip()
+            if key and key not in seen:
+                deduped_lines.append(line)
+                seen.add(key)
+        return "\n".join(deduped_lines)
+
+    def _normalize_text(self, text: str) -> str:
+        if not text:
+            return ""
+        cleaned = [line.rstrip() for line in text.splitlines()]
+        return "\n".join(line for line in cleaned if line.strip())
+
+    def _apply_cap(self, name: str, text: str) -> PipelineSection:
+        budget = SECTION_BUDGETS.get(name)
+        tokens_before = self.tokenizer.count_tokens(text)
+        if budget and tokens_before > budget:
+            truncated = self.tokenizer.truncate(text, budget)
+            tokens_after = self.tokenizer.count_tokens(truncated)
+            return PipelineSection(truncated, tokens_after)
+        return PipelineSection(text, tokens_before)
+
+    def _compute_drop_ratios(
+        self,
+        collected: Dict[str, str],
+        capped: Dict[str, PipelineSection],
+    ) -> Dict[str, float]:
+        ratios: Dict[str, float] = {}
+        for name, original in collected.items():
+            original_tokens = self.tokenizer.count_tokens(original)
+            final_tokens = capped[name].tokens
+            if original_tokens == 0:
+                ratios[name] = 0.0
+            else:
+                ratios[name] = max(0.0, 1 - (final_tokens / original_tokens))
+        return ratios
+
+    def _extract_citations(self, context: Dict[str, Any]) -> List[str]:
+        citations: List[str] = []
+        for key in sorted(context.keys()):
+            if "citation" in key.lower() or "source" in key.lower():
+                value = context[key]
+                if isinstance(value, list):
+                    citations.extend(str(item) for item in value if item)
+                elif value:
+                    citations.append(str(value))
+        # Limit to a manageable number while preserving order.
+        unique: List[str] = []
+        seen = set()
+        for entry in citations:
+            if entry not in seen:
+                unique.append(entry)
+                seen.add(entry)
+            if len(unique) >= 5 and not self.settings.use_context_pipeline_summarize:
+                break
+        return unique
+
+    def _inline_value(self, value: Any) -> str:
+        if isinstance(value, (list, tuple)):
+            return ", ".join(str(item) for item in value)
+        return str(value)

--- a/core/infrastructure/orchestration/prompt_builder.py
+++ b/core/infrastructure/orchestration/prompt_builder.py
@@ -3,7 +3,7 @@
 - Uses Jinja2 if available to support expressions (e.g., arithmetic, indexing)
 - Falls back to simple variable substitution otherwise
 """
-from typing import Any, Dict
+from typing import Any, Dict, List
 import logging
 
 from ..utils.template_utils import substitute_task_description
@@ -48,5 +48,37 @@ def build(agent: Any, prompt_template: str, context: Dict[str, Any]) -> str:
     if extra_instructions:
         prompt += f"\n\n{extra_instructions}"
 
+    context_sections = context.get("context_sections") or {}
+    if context_sections:
+        prompt += _format_context_sections(context_sections)
+
     return prompt
+
+
+def _format_context_sections(sections: Dict[str, Any]) -> str:
+    """Format compacted context sections for inclusion in the prompt."""
+
+    parts: List[str] = []
+    kb_summary = sections.get("kb_summary")
+    runtime_context = sections.get("runtime_context")
+    examples = sections.get("examples")
+    citations = sections.get("citations")
+
+    if kb_summary:
+        parts.append("\n\n## Knowledge Base Summary\n")
+        parts.append(kb_summary)
+
+    if runtime_context:
+        parts.append("\n\n## Runtime Context\n")
+        parts.append(runtime_context)
+
+    if examples:
+        parts.append("\n\n## Examples\n")
+        parts.append(examples)
+
+    if citations:
+        parts.append("\n\n## Citations\n")
+        parts.append("\n".join(f"- {citation}" for citation in citations))
+
+    return "".join(parts)
 

--- a/core/infrastructure/orchestration/system_prompt_builder.py
+++ b/core/infrastructure/orchestration/system_prompt_builder.py
@@ -1,0 +1,435 @@
+"""System prompt builder with layered template support and budgeting."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from ...domain.entities.agent import Agent
+from ..config.settings import Settings, get_settings
+from .token_utils import SimpleTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+SECTION_ORDER = [
+    "persona",
+    "goal",
+    "tool_rules",
+    "brand_voice",
+    "compliance_rules",
+    "run_context_notice",
+]
+
+
+DEFAULT_SECTION_BUDGETS = {
+    "persona": 400,
+    "goal": 80,
+    "tool_rules": 260,
+    "brand_voice": 160,
+    "compliance_rules": 180,
+    "run_context_notice": 160,
+}
+
+
+@dataclass
+class SectionContribution:
+    """Data structure for section-level overrides."""
+
+    text: str
+    replace: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SystemPromptBuilderConfig:
+    """Configuration object accepted by :class:`SystemPromptBuilder`."""
+
+    version: Optional[str] = None
+    section_budgets: Optional[Dict[str, int]] = None
+    tools: Optional[List[Dict[str, Any]]] = None
+    runtime_overrides: Optional[Dict[str, Any]] = None
+
+
+class SystemPromptBuilder:
+    """Builder responsible for composing system prompts from layered sources."""
+
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        tokenizer: Optional[SimpleTokenizer] = None,
+    ) -> None:
+        self.settings = settings or get_settings()
+        self.tokenizer = tokenizer or SimpleTokenizer()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build(
+        self,
+        agent: Agent,
+        context: Dict[str, Any],
+        config: Optional[SystemPromptBuilderConfig] = None,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Build the system message for ``agent`` within ``context``."""
+
+        config = config or SystemPromptBuilderConfig()
+        version = config.version or self.settings.system_prompt_version or "v1"
+
+        section_budgets = {**DEFAULT_SECTION_BUDGETS}
+        if config.section_budgets:
+            section_budgets.update(config.section_budgets)
+
+        profile = self._resolve_profile(context)
+        workflow = self._resolve_workflow(context)
+        task = self._resolve_task(context)
+
+        logger.debug(
+            "Building system prompt v%s (profile=%s, workflow=%s, task=%s)",
+            version,
+            profile,
+            workflow,
+            task,
+        )
+
+        layers: List[Dict[str, SectionContribution]] = []
+
+        # Global layer -------------------------------------------------
+        layers.append(
+            self._load_template_sections(
+                base_dir=self._core_prompt_dir(version),
+                relative_path=Path("global.yaml"),
+                context=context,
+            )
+        )
+
+        # Profile layer ------------------------------------------------
+        if profile:
+            layers.append(
+                self._load_template_sections(
+                    base_dir=self._profile_prompt_dir(profile, version),
+                    relative_path=Path("profile.yaml"),
+                    context=context,
+                )
+            )
+
+        # Workflow layer -----------------------------------------------
+        if workflow:
+            layers.append(
+                self._load_template_sections(
+                    base_dir=self._core_prompt_dir(version),
+                    relative_path=Path("workflows") / f"{workflow}.yaml",
+                    context=context,
+                )
+            )
+            if profile:
+                layers.append(
+                    self._load_template_sections(
+                        base_dir=self._profile_prompt_dir(profile, version),
+                        relative_path=Path("workflows") / f"{workflow}.yaml",
+                        context=context,
+                    )
+                )
+
+        # Agent layer --------------------------------------------------
+        layers.append(
+            self._load_template_sections(
+                base_dir=self._core_prompt_dir(version),
+                relative_path=Path("agents") / f"{agent.name}.yaml",
+                context=context,
+            )
+        )
+        if profile:
+            layers.append(
+                self._load_template_sections(
+                    base_dir=self._profile_prompt_dir(profile, version),
+                    relative_path=Path("agents") / f"{agent.name}.yaml",
+                    context=context,
+                )
+            )
+        layers.append(self._build_agent_layer(agent, config.tools or []))
+
+        # Task layer ---------------------------------------------------
+        if workflow and task:
+            layers.append(
+                self._load_template_sections(
+                    base_dir=self._core_prompt_dir(version),
+                    relative_path=Path("tasks") / workflow / f"{task}.yaml",
+                    context=context,
+                )
+            )
+            if profile:
+                layers.append(
+                    self._load_template_sections(
+                        base_dir=self._profile_prompt_dir(profile, version),
+                        relative_path=Path("tasks") / workflow / f"{task}.yaml",
+                        context=context,
+                    )
+                )
+
+        # Runtime layer ------------------------------------------------
+        layers.append(
+            self._build_runtime_layer(context, config.runtime_overrides)
+        )
+
+        assembled_sections: Dict[str, List[str]] = {section: [] for section in SECTION_ORDER}
+        section_sources: Dict[str, List[Dict[str, Any]]] = {section: [] for section in SECTION_ORDER}
+
+        for layer in layers:
+            for section, contribution in layer.items():
+                if not contribution or not contribution.text:
+                    continue
+                section = section.lower()
+                if section not in assembled_sections:
+                    assembled_sections[section] = []
+                    section_sources[section] = []
+                if contribution.replace:
+                    assembled_sections[section] = [contribution.text]
+                    section_sources[section] = [contribution.metadata]
+                else:
+                    assembled_sections[section].append(contribution.text)
+                    section_sources[section].append(contribution.metadata)
+
+        budget_report = {
+            "version": version,
+            "sections": {},
+            "total_tokens": 0,
+        }
+
+        final_sections: List[str] = []
+        for section in SECTION_ORDER:
+            parts = [segment.strip() for segment in assembled_sections.get(section, []) if segment.strip()]
+            if not parts:
+                continue
+            raw_text = "\n\n".join(parts).strip()
+            truncated_text = raw_text
+            truncated = False
+            token_budget = section_budgets.get(section)
+            raw_tokens = self.tokenizer.count_tokens(raw_text)
+            if token_budget and raw_tokens > token_budget:
+                truncated_text = self.tokenizer.truncate(raw_text, token_budget)
+                truncated = True
+            final_sections.append(truncated_text)
+            budget_report["sections"][section] = {
+                "tokens": self.tokenizer.count_tokens(truncated_text),
+                "budget": token_budget,
+                "truncated": truncated,
+                "sources": section_sources.get(section, []),
+            }
+            budget_report["total_tokens"] += budget_report["sections"][section]["tokens"]
+
+        system_message = "\n\n".join(final_sections).strip()
+        budget_report["system_message_length"] = len(system_message)
+
+        return system_message, budget_report
+
+    # ------------------------------------------------------------------
+    # Layer helpers
+    # ------------------------------------------------------------------
+    def _build_agent_layer(
+        self,
+        agent: Agent,
+        tools: List[Dict[str, Any]],
+    ) -> Dict[str, SectionContribution]:
+        sections: Dict[str, SectionContribution] = {}
+
+        persona_parts: List[str] = []
+        if agent.system_message:
+            persona_parts.append(agent.system_message.strip())
+        if agent.backstory:
+            persona_parts.append(agent.backstory.strip())
+        if persona_parts:
+            sections["persona"] = SectionContribution(
+                text="\n\n".join(persona_parts),
+                metadata={"source": "agent"},
+            )
+
+        if agent.goal:
+            sections["goal"] = SectionContribution(
+                text=f"Primary goal: {agent.goal.strip()}",
+                metadata={"source": "agent"},
+            )
+
+        brand_voice = agent.metadata.get("brand_voice") if isinstance(agent.metadata, dict) else None
+        if brand_voice:
+            sections["brand_voice"] = SectionContribution(
+                text=f"Brand voice guidance: {brand_voice}",
+                metadata={"source": "agent.metadata"},
+            )
+
+        tool_rules = self._build_tool_rules(tools)
+        if tool_rules:
+            sections["tool_rules"] = SectionContribution(
+                text=tool_rules,
+                metadata={"source": "agent.tools"},
+            )
+
+        return sections
+
+    def _build_runtime_layer(
+        self,
+        context: Dict[str, Any],
+        runtime_overrides: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, SectionContribution]:
+        sections: Dict[str, SectionContribution] = {}
+
+        lines: List[str] = []
+        client_profile = context.get("client_profile") or context.get("client_name")
+        if client_profile:
+            lines.append(f"Client profile: {client_profile}")
+        target_audience = context.get("target_audience")
+        if target_audience:
+            lines.append(f"Target audience: {target_audience}")
+        tone = context.get("tone")
+        if tone:
+            lines.append(f"Preferred tone: {tone}")
+        if context.get("workflow_template"):
+            lines.append(f"Workflow template: {context['workflow_template']}")
+        if context.get("task_name"):
+            lines.append(f"Current task: {context['task_name']}")
+        if context.get("custom_instructions"):
+            lines.append(f"Custom instructions: {context['custom_instructions']}")
+
+        if lines:
+            sections["run_context_notice"] = SectionContribution(
+                text="Runtime context:\n- " + "\n- ".join(lines),
+                metadata={"source": "runtime"},
+            )
+
+        if runtime_overrides:
+            for section, value in runtime_overrides.items():
+                if not value:
+                    continue
+                sections[section] = SectionContribution(
+                    text=str(value),
+                    metadata={"source": "runtime_override"},
+                    replace=True,
+                )
+
+        compliance = context.get("compliance_requirements")
+        if compliance and "compliance_rules" not in sections:
+            sections["compliance_rules"] = SectionContribution(
+                text=str(compliance),
+                metadata={"source": "runtime"},
+            )
+
+        return sections
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _build_tool_rules(self, tools: List[Dict[str, Any]]) -> str:
+        if not tools:
+            return ""
+
+        lines: List[str] = ["You have access to the following tools:"]
+        for tool in tools:
+            name = tool.get("name")
+            description = tool.get("description", "").strip()
+            if name and description:
+                lines.append(f"- {name}: {description}")
+            elif name:
+                lines.append(f"- {name}")
+
+        try:
+            from ..tools.tool_names import ToolNames
+
+            lines.extend(
+                [
+                    "",
+                    "When invoking tools, use the exact syntax:",
+                    f"[{ToolNames.RAG_GET_CLIENT_CONTENT}] client_name [/{ToolNames.RAG_GET_CLIENT_CONTENT}]",
+                    f"[{ToolNames.RAG_GET_CLIENT_CONTENT}] client_name, document_name [/{ToolNames.RAG_GET_CLIENT_CONTENT}]",
+                    f"[{ToolNames.RAG_SEARCH_CONTENT}] client_name, search_query [/{ToolNames.RAG_SEARCH_CONTENT}]",
+                    f"[{ToolNames.RAG_SEARCH_CONTENT}] search_query [/{ToolNames.RAG_SEARCH_CONTENT}] (defaults to 'siebert' if client is omitted)",
+                    f"[{ToolNames.WEB_SEARCH_SERPER}] your search query [/{ToolNames.WEB_SEARCH_SERPER}]",
+                    f"[{ToolNames.WEB_SEARCH_PERPLEXITY}] your search query [/{ToolNames.WEB_SEARCH_PERPLEXITY}]",
+                    "",
+                    "Critical rules:",
+                    "- Use the exact tool names listed above",
+                    "- Provide concrete queries for rag_search_content",
+                    "- Separate parameters with commas for multi-argument tools",
+                    "- Do not use placeholders like 'TOOL_NAME'",
+                ]
+            )
+        except Exception:  # pragma: no cover - defensive, ToolNames always available in runtime
+            lines.append(
+                "Ensure tool calls use the canonical name and are wrapped in [TOOL] ... [/TOOL] blocks."
+            )
+
+        return "\n".join(lines)
+
+    def _load_template_sections(
+        self,
+        base_dir: Path,
+        relative_path: Path,
+        context: Dict[str, Any],
+    ) -> Dict[str, SectionContribution]:
+        if not base_dir:
+            return {}
+        path = base_dir / relative_path
+        if not path.exists():
+            return {}
+
+        try:
+            with open(path, "r", encoding="utf-8") as fp:
+                data = yaml.safe_load(fp) or {}
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:
+            logger.warning("Failed to load system prompt template %s: %s", path, exc)
+            return {}
+
+        sections: Dict[str, SectionContribution] = {}
+        raw_sections = data.get("sections", {})
+        for section, value in raw_sections.items():
+            text = ""
+            replace = False
+            if isinstance(value, dict):
+                text = value.get("text") or value.get("content") or ""
+                replace = bool(value.get("replace"))
+            else:
+                text = str(value)
+
+            rendered = self._render_template(text, context).strip()
+            if rendered:
+                sections[section.lower()] = SectionContribution(
+                    text=rendered,
+                    replace=replace,
+                    metadata={"source": str(path)},
+                )
+
+        return sections
+
+    def _render_template(self, template_text: str, context: Dict[str, Any]) -> str:
+        if not template_text:
+            return ""
+
+        try:
+            from jinja2 import Template  # type: ignore
+
+            return Template(template_text).render(**context)
+        except Exception:
+            # As a safe fallback simply return the raw template text; system prompts
+            # primarily use literals so this is acceptable.
+            return template_text
+
+    def _core_prompt_dir(self, version: str) -> Path:
+        return Path(__file__).resolve().parent.parent.parent / "prompts" / "system" / version
+
+    def _profile_prompt_dir(self, profile: str, version: str) -> Path:
+        base = Path(self.settings.profiles_dir) / profile / "prompts" / "system" / version
+        return base
+
+    def _resolve_profile(self, context: Dict[str, Any]) -> Optional[str]:
+        return context.get("client_profile") or context.get("client_name")
+
+    def _resolve_workflow(self, context: Dict[str, Any]) -> Optional[str]:
+        return context.get("workflow_type") or context.get("workflow_template")
+
+    def _resolve_task(self, context: Dict[str, Any]) -> Optional[str]:
+        return context.get("task_id") or context.get("task_name")

--- a/core/infrastructure/orchestration/token_utils.py
+++ b/core/infrastructure/orchestration/token_utils.py
@@ -1,0 +1,80 @@
+"""Utility helpers for lightweight token estimation and truncation.
+
+These helpers intentionally avoid external tokenizer dependencies so that
+unit tests can run without optional packages such as ``tiktoken``.
+The implementation relies on a simple regular-expression based approach
+that preserves whitespace while counting tokens in a deterministic way.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+
+_TOKEN_PATTERN = re.compile(r"\S+\s*")
+
+
+@dataclass
+class TokenSlice:
+    """Representation of a token span within a string."""
+
+    text: str
+    end: int
+
+
+class SimpleTokenizer:
+    """Very small helper used to approximate token counts.
+
+    The goal is not to perfectly match any provider specific tokenizer but to
+    obtain a stable metric for budgeting logic. Each "token" corresponds to a
+    contiguous block of non-whitespace characters along with their trailing
+    whitespace. This makes truncation operations preserve the original layout
+    as much as possible.
+    """
+
+    def tokenize(self, text: str) -> Iterable[TokenSlice]:
+        """Yield :class:`TokenSlice` objects for the supplied ``text``."""
+
+        if not text:
+            return []
+        return (
+            TokenSlice(match.group(0), match.end())
+            for match in _TOKEN_PATTERN.finditer(text)
+        )
+
+    def count_tokens(self, text: str) -> int:
+        """Return an estimated token count for ``text``."""
+
+        if not text:
+            return 0
+        return len(_TOKEN_PATTERN.findall(text))
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Truncate ``text`` so that it does not exceed ``max_tokens`` tokens."""
+
+        if not text or max_tokens <= 0:
+            return ""
+
+        count = 0
+        cutoff = None
+        for slice_ in self.tokenize(text):
+            count += 1
+            cutoff = slice_.end
+            if count >= max_tokens:
+                break
+
+        # Nothing to truncate.
+        total_tokens = self.count_tokens(text)
+        if total_tokens <= max_tokens:
+            return text.strip()
+
+        truncated = text[: cutoff or 0].rstrip()
+        if not truncated:
+            return ""
+
+        # Append ellipsis to indicate truncation while keeping spacing tidy.
+        if not truncated.endswith("…"):
+            truncated = f"{truncated} …"
+        return truncated

--- a/core/prompts/system/v1/agents/compliance_specialist.yaml
+++ b/core/prompts/system/v1/agents/compliance_specialist.yaml
@@ -1,0 +1,5 @@
+sections:
+  compliance_rules:
+    text: |
+      Apply strict regulatory review. Document every required disclosure and mark
+      any unresolved compliance issues for escalation.

--- a/core/prompts/system/v1/agents/copywriter.yaml
+++ b/core/prompts/system/v1/agents/copywriter.yaml
@@ -1,0 +1,5 @@
+sections:
+  brand_voice:
+    text: |
+      Deliver polished copy aligned with the client voice while keeping structure
+      and section objectives intact.

--- a/core/prompts/system/v1/agents/rag_specialist.yaml
+++ b/core/prompts/system/v1/agents/rag_specialist.yaml
@@ -1,0 +1,5 @@
+sections:
+  persona:
+    text: |
+      Focus on extracting and structuring knowledge base material before other
+      agents operate. Highlight document titles and reasons for relevance.

--- a/core/prompts/system/v1/agents/research_specialist.yaml
+++ b/core/prompts/system/v1/agents/research_specialist.yaml
@@ -1,0 +1,5 @@
+sections:
+  goal:
+    text: |
+      Prioritize recent, high-signal findings and annotate why each source matters
+      for downstream content creation.

--- a/core/prompts/system/v1/global.yaml
+++ b/core/prompts/system/v1/global.yaml
@@ -1,0 +1,13 @@
+sections:
+  persona:
+    text: |
+      You are part of the CGS orchestrated multi-agent content generation platform.
+      Coordinate with other specialists, remain factual, and keep outputs organized.
+  compliance_rules:
+    text: |
+      Respect all compliance notices included in the workflow context. Escalate any
+      potential regulatory conflicts instead of inventing information.
+  run_context_notice:
+    text: |
+      Confirm the active workflow and task context before executing actions. Ask for
+      clarification if required data is missing.

--- a/core/prompts/system/v1/tasks/enhanced_article/task4_compliance_review.yaml
+++ b/core/prompts/system/v1/tasks/enhanced_article/task4_compliance_review.yaml
@@ -1,0 +1,6 @@
+sections:
+  compliance_rules:
+    text: |
+      You are reviewing the assembled article for compliance. Verify every claim,
+      ensure disclosures are explicit, and refuse to approve sections lacking
+      substantiation.

--- a/core/prompts/system/v1/tasks/premium_newsletter/task3_newsletter_creation.yaml
+++ b/core/prompts/system/v1/tasks/premium_newsletter/task3_newsletter_creation.yaml
@@ -1,0 +1,5 @@
+sections:
+  persona:
+    text: |
+      Operate as the final assembler ensuring each newsletter section meets the
+      specified structure, word counts, and client voice guidance from upstream steps.

--- a/core/prompts/system/v1/workflows/enhanced_article.yaml
+++ b/core/prompts/system/v1/workflows/enhanced_article.yaml
@@ -1,0 +1,9 @@
+sections:
+  goal:
+    text: |
+      Workflow objective: deliver an enhanced educational article that combines a
+      research brief, curated findings, polished narrative, and final compliance review.
+  compliance_rules:
+    text: |
+      Integrate FINRA/SEC guidance into each stage. Flag unsupported claims and ensure
+      citations align with approved knowledge sources.

--- a/core/prompts/system/v1/workflows/premium_newsletter.yaml
+++ b/core/prompts/system/v1/workflows/premium_newsletter.yaml
@@ -1,0 +1,9 @@
+sections:
+  goal:
+    text: |
+      Workflow objective: produce a premium client newsletter that merges enhanced
+      context, premium-source synthesis, and brand-faithful final assembly.
+  brand_voice:
+    text: |
+      Maintain the client-specific newsletter voice: confident, data-backed, and
+      actionable for active investors.

--- a/data/profiles/default/prompts/system/v1/profile.yaml
+++ b/data/profiles/default/prompts/system/v1/profile.yaml
@@ -1,0 +1,5 @@
+sections:
+  brand_voice:
+    text: |
+      Default brand voice: professional, educational, and concise. Adapt tone to the
+      specified target audience while avoiding colloquialisms unless requested.

--- a/data/profiles/siebert/agents/research_agent.yaml
+++ b/data/profiles/siebert/agents/research_agent.yaml
@@ -20,7 +20,7 @@ tools:
 - web_search
 - rag_get_client_content
 - rag_search_content
-is_active: false
+is_active: true
 metadata:
   client: siebert
   domain_cap: 10

--- a/data/profiles/siebert/prompts/system/v1/agents/copywriter.yaml
+++ b/data/profiles/siebert/prompts/system/v1/agents/copywriter.yaml
@@ -1,0 +1,5 @@
+sections:
+  brand_voice:
+    text: |
+      Reinforce Siebert newsletter hallmarks: eight curated sections, Malek spotlight,
+      and empowerment messaging tailored to Gen Z investors.

--- a/data/profiles/siebert/prompts/system/v1/agents/rag_specialist.yaml
+++ b/data/profiles/siebert/prompts/system/v1/agents/rag_specialist.yaml
@@ -1,0 +1,5 @@
+sections:
+  goal:
+    text: |
+      Focus retrieval on Siebert's KB collections: product overviews, Malek commentaries,
+      and regulatory updates. Deliver bullet-ready findings for downstream agents.

--- a/data/profiles/siebert/prompts/system/v1/profile.yaml
+++ b/data/profiles/siebert/prompts/system/v1/profile.yaml
@@ -1,0 +1,9 @@
+sections:
+  brand_voice:
+    text: |
+      Siebert Financial voice: empowering, transparency-first, and optimistic about
+      long-term investing. Highlight the firm's differentiators and regulatory rigor.
+  compliance_rules:
+    text: |
+      Incorporate Siebert's compliance expectations: cite approved sources only,
+      acknowledge market risks, and maintain FINRA/SEC-aligned disclosures.

--- a/data/profiles/siebert/prompts/system/v1/workflows/premium_newsletter.yaml
+++ b/data/profiles/siebert/prompts/system/v1/workflows/premium_newsletter.yaml
@@ -1,0 +1,5 @@
+sections:
+  brand_voice:
+    text: |
+      Emphasize Siebert's differentiators in each section: client-first service,
+      transparency, and actionable investing insights with compliance-ready language.

--- a/tests/fixtures/system_prompts/enhanced_article_task1_brief.txt
+++ b/tests/fixtures/system_prompts/enhanced_article_task1_brief.txt
@@ -1,0 +1,50 @@
+You are part of the CGS orchestrated multi-agent content generation platform.
+Coordinate with other specialists, remain factual, and keep outputs organized.
+
+Focus on extracting and structuring knowledge base material before other
+agents operate. Highlight document titles and reasons for relevance.
+
+ROLE: RAG Specialist
+GOALS:
+  - Retrieve client knowledge and craft structured briefs
+TOOL POLICY:
+  - Use [rag_get_client_content] and [rag_search_content] for document retrieval
+GUARDRAILS:
+  - Base outputs only on retrieved content
+OUTPUT:
+  - Markdown brief summarizing findings
+
+You are an expert at analyzing client documentation and creating detailed project briefs that guide content creation.
+
+Workflow objective: deliver an enhanced educational article that combines a
+research brief, curated findings, polished narrative, and final compliance review.
+
+Focus retrieval on Siebert's KB collections: product overviews, Malek commentaries,
+and regulatory updates. Deliver bullet-ready findings for downstream agents.
+
+Primary goal: Retrieve and analyze client knowledge base content to create comprehensive project briefs
+
+Siebert Financial voice: empowering, transparency-first, and optimistic about
+long-term investing. Highlight the firm's differentiators and regulatory rigor.
+
+Respect all compliance notices included in the workflow context. Escalate any
+potential regulatory conflicts instead of inventing information.
+
+Incorporate Siebert's compliance expectations: cite approved sources only,
+acknowledge market risks, and maintain FINRA/SEC-aligned disclosures.
+
+Integrate FINRA/SEC guidance into each stage. Flag unsupported claims and ensure
+citations align with approved knowledge sources.
+
+Use only verified statements and provide disclosures when necessary.
+
+Confirm the active workflow and task context before executing actions. Ask for
+clarification if required data is missing.
+
+Runtime context:
+- Client profile: siebert
+- Target audience: Gen Z investors
+- Preferred tone: confident
+- Workflow template: enhanced_article
+- Current task: Brief Creation
+- Custom instructions: Highlight actionable insights and cite approved sources.

--- a/tests/fixtures/system_prompts/enhanced_article_task2_research.txt
+++ b/tests/fixtures/system_prompts/enhanced_article_task2_research.txt
@@ -1,0 +1,47 @@
+You are part of the CGS orchestrated multi-agent content generation platform.
+Coordinate with other specialists, remain factual, and keep outputs organized.
+
+ROLE: Research Specialist
+GOALS:
+  - Gather complete newsletter research using the appropriate tool(s)
+TOOL POLICY:
+  - Use [web_search] or [perplexity_search] as directed by the task/workflow; include blog.siebert.com for Malek insights when required
+GUARDRAILS:
+  - Respect timeframe and exclusions; ensure Section 5 coverage
+OUTPUT:
+  - Extensive research text with source citations
+
+You are a highly efficient financial researcher who specializes in single-tool Perplexity API research. You excel at extracting comprehensive financial content from premium sources in one optimized call, with mandatory integration of Siebert blog content for Section 5.
+
+Workflow objective: deliver an enhanced educational article that combines a
+research brief, curated findings, polished narrative, and final compliance review.
+
+Prioritize recent, high-signal findings and annotate why each source matters
+for downstream content creation.
+
+Primary goal: Execute single-tool Perplexity research for Siebert newsletter with mandatory blog.siebert.com integration
+
+Siebert Financial voice: empowering, transparency-first, and optimistic about
+long-term investing. Highlight the firm's differentiators and regulatory rigor.
+
+Respect all compliance notices included in the workflow context. Escalate any
+potential regulatory conflicts instead of inventing information.
+
+Incorporate Siebert's compliance expectations: cite approved sources only,
+acknowledge market risks, and maintain FINRA/SEC-aligned disclosures.
+
+Integrate FINRA/SEC guidance into each stage. Flag unsupported claims and ensure
+citations align with approved knowledge sources.
+
+Use only verified statements and provide disclosures when necessary.
+
+Confirm the active workflow and task context before executing actions. Ask for
+clarification if required data is missing.
+
+Runtime context:
+- Client profile: siebert
+- Target audience: Gen Z investors
+- Preferred tone: confident
+- Workflow template: enhanced_article
+- Current task: Web Research & Brief Enhancement
+- Custom instructions: Highlight actionable insights and cite approved sources.

--- a/tests/fixtures/system_prompts/enhanced_article_task4_compliance_review.txt
+++ b/tests/fixtures/system_prompts/enhanced_article_task4_compliance_review.txt
@@ -1,0 +1,51 @@
+You are part of the CGS orchestrated multi-agent content generation platform.
+Coordinate with other specialists, remain factual, and keep outputs organized.
+
+ROLE: FINRA/SEC Compliance Reviewer
+GOALS:
+  - Ensure newsletter meets regulations and integrate fixes
+TOOL POLICY:
+  - No external tools
+GUARDRAILS:
+  - Distinguish fact vs opinion; include required disclaimers
+OUTPUT:
+  - Corrected newsletter ready for publication
+
+You are a FINRA and SEC regulatory specialist who reviews retail investor communications for compliance. You ensure newsletters meet regulatory standards while preserving the authentic Gen Z voice and educational value.
+
+Workflow objective: deliver an enhanced educational article that combines a
+research brief, curated findings, polished narrative, and final compliance review.
+
+Primary goal: Review and revise the newsletter for FINRA/SEC compliance so the final version is publication-ready, with all corrections integrated and without altering content structure or voice
+
+Siebert Financial voice: empowering, transparency-first, and optimistic about
+long-term investing. Highlight the firm's differentiators and regulatory rigor.
+
+Respect all compliance notices included in the workflow context. Escalate any
+potential regulatory conflicts instead of inventing information.
+
+Incorporate Siebert's compliance expectations: cite approved sources only,
+acknowledge market risks, and maintain FINRA/SEC-aligned disclosures.
+
+Integrate FINRA/SEC guidance into each stage. Flag unsupported claims and ensure
+citations align with approved knowledge sources.
+
+Apply strict regulatory review. Document every required disclosure and mark
+any unresolved compliance issues for escalation.
+
+You are reviewing the assembled article for compliance. Verify every claim,
+ensure disclosures are explicit, and refuse to approve sections lacking
+substantiation.
+
+Use only verified statements and provide disclosures when necessary.
+
+Confirm the active workflow and task context before executing actions. Ask for
+clarification if required data is missing.
+
+Runtime context:
+- Client profile: siebert
+- Target audience: Gen Z investors
+- Preferred tone: confident
+- Workflow template: enhanced_article
+- Current task: FINRA/SEC Compliance Review & Validation
+- Custom instructions: Highlight actionable insights and cite approved sources.

--- a/tests/fixtures/system_prompts/premium_newsletter_task3_newsletter_creation.txt
+++ b/tests/fixtures/system_prompts/premium_newsletter_task3_newsletter_creation.txt
@@ -1,0 +1,58 @@
+You are part of the CGS orchestrated multi-agent content generation platform.
+Coordinate with other specialists, remain factual, and keep outputs organized.
+
+ROLE: Siebert Newsletter Copywriter
+GOALS:
+  - Assemble final 8-section newsletter with precise word counts
+TOOL POLICY:
+  - Use [perplexity_search], [web_search], [rag_get_client_content], [rag_search_content] as needed
+GUARDRAILS:
+  - Cite only allowed URLs; maintain brand voice and compliance
+OUTPUT:
+  - JSON sections payload with citations
+
+You are Siebert's premium newsletter copywriter who assembles content into the company's exact 8-section format with precise word counts and mandatory Malek integration.
+
+Operate as the final assembler ensuring each newsletter section meets the
+specified structure, word counts, and client voice guidance from upstream steps.
+
+Workflow objective: produce a premium client newsletter that merges enhanced
+context, premium-source synthesis, and brand-faithful final assembly.
+
+Primary goal: Assemble Siebert newsletter in exact 8-section structure with precise word counts and mandatory Section 5 Malek content
+
+Siebert Financial voice: empowering, transparency-first, and optimistic about
+long-term investing. Highlight the firm's differentiators and regulatory rigor.
+
+Maintain the client-specific newsletter voice: confident, data-backed, and
+actionable for active investors.
+
+Emphasize Siebert's differentiators in each section: client-first service,
+transparency, and actionable investing insights with compliance-ready language.
+
+Deliver polished copy aligned with the client voice while keeping structure
+and section objectives intact.
+
+Reinforce Siebert newsletter hallmarks: eight curated sections, Malek spotlight,
+and empowerment messaging tailored to Gen Z investors.
+
+Brand voice guidance: Professional yet conversational, educational, empowering
+
+Respect all compliance notices included in the workflow context. Escalate any
+potential regulatory conflicts instead of inventing information.
+
+Incorporate Siebert's compliance expectations: cite approved sources only,
+acknowledge market risks, and maintain FINRA/SEC-aligned disclosures.
+
+Use only verified statements and provide disclosures when necessary.
+
+Confirm the active workflow and task context before executing actions. Ask for
+clarification if required data is missing.
+
+Runtime context:
+- Client profile: siebert
+- Target audience: Gen Z investors
+- Preferred tone: confident
+- Workflow template: premium_newsletter
+- Current task: Precision Newsletter Creation
+- Custom instructions: Highlight actionable insights and cite approved sources.

--- a/tests/test_agent_executor_system_prompt.py
+++ b/tests/test_agent_executor_system_prompt.py
@@ -1,0 +1,35 @@
+"""Tests covering AgentExecutor system prompt fallbacks."""
+
+from core.domain.entities.agent import Agent, AgentRole
+from core.domain.value_objects.provider_config import ProviderConfig
+from core.infrastructure.config.settings import Settings
+from core.infrastructure.orchestration.agent_executor import AgentExecutor
+
+
+def create_agent() -> Agent:
+    return Agent(
+        name="legacy_agent",
+        role=AgentRole.RESEARCHER,
+        system_message="Legacy persona",
+        backstory="Legacy backstory",
+        goal="Legacy goal",
+    )
+
+
+def test_system_prompt_builder_disabled_uses_legacy_message():
+    settings = Settings(secret_key="test-key", use_system_prompt_builder_v2=False)
+    executor = AgentExecutor(
+        agent_repository=None,
+        llm_provider=None,
+        provider_config=ProviderConfig(),
+        settings=settings,
+    )
+
+    agent = create_agent()
+    context = {"client_profile": "default"}
+
+    legacy_message = executor._prepare_system_message(agent, context)
+    system_message, report = executor._build_system_message(agent, context)
+
+    assert system_message == legacy_message
+    assert report == {}

--- a/tests/test_research_agent.py
+++ b/tests/test_research_agent.py
@@ -1,5 +1,6 @@
 import pytest
 
+from core.infrastructure.config.settings import Settings
 from core.infrastructure.repositories.yaml_agent_repository import YamlAgentRepository
 from core.infrastructure.orchestration.agent_executor import AgentExecutor
 from core.infrastructure.tools.tool_names import ToolNames
@@ -48,7 +49,12 @@ async def test_research_agent_triggers_perplexity():
     assert "blog.siebert.com" in agent.system_message
 
     provider = DummyProvider()
-    executor = AgentExecutor(repo, provider, ProviderConfig())
+    executor = AgentExecutor(
+        repo,
+        provider,
+        ProviderConfig(),
+        settings=Settings(secret_key="test-key"),
+    )
 
     calls = {}
 

--- a/tests/test_system_prompt_builder_snapshots.py
+++ b/tests/test_system_prompt_builder_snapshots.py
@@ -1,0 +1,87 @@
+"""Snapshot tests for the layered system prompt builder."""
+
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+from core.domain.entities.agent import Agent
+from core.infrastructure.config.settings import Settings
+from core.infrastructure.orchestration.system_prompt_builder import (
+    SystemPromptBuilder,
+    SystemPromptBuilderConfig,
+)
+
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "system_prompts"
+TEST_SETTINGS = Settings(secret_key="snapshot-test")
+
+
+def load_agent(profile: str, agent_name: str) -> Agent:
+    agent_path = Path(TEST_SETTINGS.profiles_dir) / profile / "agents" / f"{agent_name}.yaml"
+    with open(agent_path, "r", encoding="utf-8") as fh:
+        data: Dict[str, any] = yaml.safe_load(fh) or {}
+    data.setdefault("name", agent_name)
+    data.setdefault("role", data.get("role", "researcher"))
+    agent = Agent.from_dict(data)
+    agent.metadata["client_profile"] = profile
+    return agent
+
+
+def build_context(workflow: str, task_id: str, task_name: str, profile: str) -> Dict[str, str]:
+    return {
+        "client_profile": profile,
+        "workflow_type": workflow,
+        "workflow_template": workflow,
+        "task_id": task_id,
+        "task_name": task_name,
+        "target_audience": "Gen Z investors",
+        "tone": "confident",
+        "custom_instructions": "Highlight actionable insights and cite approved sources.",
+        "compliance_requirements": "Use only verified statements and provide disclosures when necessary.",
+    }
+
+
+SNAPSHOTS = [
+    (
+        "enhanced_article",
+        "task1_brief",
+        "Brief Creation",
+        "rag_specialist",
+        "enhanced_article_task1_brief.txt",
+    ),
+    (
+        "enhanced_article",
+        "task2_research",
+        "Web Research & Brief Enhancement",
+        "research_specialist",
+        "enhanced_article_task2_research.txt",
+    ),
+    (
+        "enhanced_article",
+        "task4_compliance_review",
+        "FINRA/SEC Compliance Review & Validation",
+        "compliance_specialist",
+        "enhanced_article_task4_compliance_review.txt",
+    ),
+    (
+        "premium_newsletter",
+        "task3_newsletter_creation",
+        "Precision Newsletter Creation",
+        "copywriter",
+        "premium_newsletter_task3_newsletter_creation.txt",
+    ),
+]
+
+
+def test_system_prompt_builder_snapshots():
+    builder = SystemPromptBuilder(settings=TEST_SETTINGS)
+
+    for workflow, task_id, task_name, agent_name, fixture_name in SNAPSHOTS:
+        agent = load_agent("siebert", agent_name)
+        context = build_context(workflow, task_id, task_name, "siebert")
+        system_prompt, _ = builder.build(agent, context, SystemPromptBuilderConfig())
+        expected_path = FIXTURES_DIR / fixture_name
+        assert expected_path.exists(), f"Missing snapshot fixture: {expected_path}"
+        expected = expected_path.read_text(encoding="utf-8").strip()
+        assert system_prompt.strip() == expected

--- a/tests/unit/test_context_pipeline.py
+++ b/tests/unit/test_context_pipeline.py
@@ -1,0 +1,44 @@
+"""Unit tests for the context compaction pipeline."""
+
+from core.infrastructure.config.settings import Settings
+from core.infrastructure.orchestration import context_pipeline
+from core.infrastructure.orchestration.context_pipeline import ContextPipeline
+
+
+def sample_context() -> dict:
+    return {
+        "task1_brief_output": "Line A\nLine A\nLine B",
+        "task2_research_output": "Line B\nLine C",
+        "topic": "Inflation outlook 2025",
+        "target_audience": "Gen Z investors",
+        "tone": "confident",
+        "sources": ["https://example.com/a", "https://example.com/b"],
+        "duplicate_sources": ["https://example.com/a"],
+    }
+
+
+def test_pipeline_dedupe_and_normalize():
+    pipeline = ContextPipeline(settings=Settings(secret_key="test-key"))
+    result = pipeline.build(sample_context())
+
+    kb_summary = result["kb_summary"]
+    assert kb_summary.count("Line A") == 1
+    assert "Line C" in kb_summary
+
+    runtime_context = result["runtime_context"]
+    assert "Topic" in runtime_context
+    assert "Tone" in runtime_context
+
+    citations = result["citations"]
+    assert citations[0] == "https://example.com/a"
+    assert len(citations) <= 5
+
+
+def test_pipeline_hard_cap(monkeypatch):
+    monkeypatch.setitem(context_pipeline.SECTION_BUDGETS, "kb_summary", 2)
+    pipeline = ContextPipeline(settings=Settings(secret_key="test-key"))
+    result = pipeline.build(sample_context())
+
+    notes = result["notes"]
+    assert notes["drop_ratios"]["kb_summary"] > 0
+    assert result["kb_summary"].endswith("…")

--- a/tests/unit/test_system_prompt_builder.py
+++ b/tests/unit/test_system_prompt_builder.py
@@ -1,0 +1,58 @@
+"""Unit tests for the layered system prompt builder."""
+
+from core.domain.entities.agent import Agent, AgentRole
+from core.infrastructure.config.settings import Settings
+from core.infrastructure.orchestration.system_prompt_builder import (
+    SystemPromptBuilder,
+    SystemPromptBuilderConfig,
+)
+
+
+def create_agent() -> Agent:
+    return Agent(
+        name="unit_agent",
+        role=AgentRole.RESEARCHER,
+        system_message="word1 word2 word3 word4 word5 word6",
+        backstory="Backstory text that should be removed when overridden.",
+        goal="Deliver accurate summaries.",
+    )
+
+
+def create_context() -> dict:
+    return {
+        "client_profile": "default",
+        "workflow_type": "enhanced_article",
+        "workflow_template": "enhanced_article",
+        "task_id": "task1_brief",
+        "task_name": "Brief Creation",
+    }
+
+
+def test_runtime_override_precedence():
+    settings = Settings(secret_key="test-key")
+    builder = SystemPromptBuilder(settings=settings)
+    agent = create_agent()
+    context = create_context()
+
+    config = SystemPromptBuilderConfig(
+        runtime_overrides={"persona": "Runtime persona override."}
+    )
+
+    system_message, report = builder.build(agent, context, config)
+
+    assert "Runtime persona override." in system_message
+    assert "Backstory text" not in system_message
+    assert report["sections"]["persona"]["truncated"] is False
+
+
+def test_section_budget_truncation():
+    settings = Settings(secret_key="test-key")
+    builder = SystemPromptBuilder(settings=settings)
+    agent = create_agent()
+    context = create_context()
+
+    config = SystemPromptBuilderConfig(section_budgets={"persona": 3})
+    system_message, report = builder.build(agent, context, config)
+
+    assert report["sections"]["persona"]["truncated"] is True
+    assert "word4" not in system_message


### PR DESCRIPTION
## Summary
- add versioned SystemPromptBuilder with layered templates, token budgeting, and runtime overrides
- implement ContextPipeline v1 to dedupe/normalize context, feed compacted sections into prompts, and surface new templates per workflow/profile
- extend logging, settings, and tests (unit + snapshots) to cover the new builder, pipeline, and legacy fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98e63410c8327a6df19cf155d68ff