### PR TITLE
Add granular cost ledger: run_cost_events + per-call LLM/Tool tracking

### DIFF
--- a/supabase_tracking_schema.sql
+++ b/supabase_tracking_schema.sql
@@ -85,3 +85,36 @@ CREATE TABLE IF NOT EXISTS run_document_chunks (
 
 CREATE INDEX IF NOT EXISTS idx_run_document_chunks_run_id ON run_document_chunks(run_id);
 
+-- =====================================================
+-- RUN COST EVENTS (granular per-call ledger for LLM and tools)
+-- =====================================================
+CREATE TABLE IF NOT EXISTS run_cost_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    timestamp TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    event_type VARCHAR(20) CHECK (event_type IN ('llm','tool')),
+    agent_name VARCHAR(200),
+    provider_name VARCHAR(100),
+    model_name VARCHAR(200),
+    tool_name VARCHAR(200),
+    cost_usd NUMERIC(12,6),
+    cost_source VARCHAR(50),
+    -- LLM-specific
+    tokens_prompt BIGINT,
+    tokens_completion BIGINT,
+    tokens_total BIGINT,
+    -- Tool-specific / hybrid
+    units NUMERIC(12,3),
+    unit_cost_usd NUMERIC(12,6),
+    cost_per_1k_tokens_usd NUMERIC(12,6),
+    usage_tokens BIGINT,
+    duration_seconds NUMERIC(10,3),
+    metadata JSONB DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_cost_events_run_id ON run_cost_events(run_id);
+CREATE INDEX IF NOT EXISTS idx_run_cost_events_type ON run_cost_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_run_cost_events_timestamp ON run_cost_events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_run_cost_events_provider ON run_cost_events(provider_name);
+CREATE INDEX IF NOT EXISTS idx_run_cost_events_tool ON run_cost_events(tool_name);
+


### PR DESCRIPTION
This PR introduces granular, per-call cost tracking for both LLM requests and tool executions.

Key changes:
- SQL: add run_cost_events table (with helpful indexes) to store a ledger of cost events for each workflow run
- SupabaseTracker: new methods log_llm_call and log_tool_execution to persist cost events
- AgentExecutor: persist cost events after each LLM call and tool execution (tokens/units/cost/duration + metadata)
- Wire tracker/run_id through tool processing

Benefits:
- Enables detailed cost analysis for a single workflow (by provider, by tool, by agent, over time)
- Single source of truth for billing/audit

Notes:
- Requires executing the DDL in supabase_tracking_schema.sql on the Supabase project
- No breaking changes to existing tables; workflow_runs and agent_executions remain for aggregates

Once merged, we can add saved SQL queries/dashboards in Supabase for quick analytics.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author