### PR TITLE
Improve token usage parsing and caching cost coverage

### DIFF
--- a/core/infrastructure/orchestration/agent_executor.py
+++ b/core/infrastructure/orchestration/agent_executor.py
@@ -962,20 +962,24 @@ class AgentExecutor:
                 # Handle different response formats
                 if isinstance(usage, dict):
                     return TokenUsage(
-                        prompt_tokens=usage.get("prompt_tokens", 0),
-                        completion_tokens=usage.get("completion_tokens", 0),
+                        prompt_tokens=self._extract_prompt_tokens(usage),
+                        completion_tokens=self._extract_completion_tokens(usage),
                         total_tokens=usage.get("total_tokens", 0),
-                        reasoning_tokens=usage.get("reasoning_tokens", 0),
+                        reasoning_tokens=self._extract_reasoning_tokens(usage),
                         cached_tokens=usage.get("cached_tokens", 0),
+                        cache_read_tokens=self._extract_cache_read_tokens(usage),
+                        cache_write_tokens=self._extract_cache_write_tokens(usage),
                     )
                 else:
                     # Handle object-style usage
                     return TokenUsage(
-                        prompt_tokens=getattr(usage, "prompt_tokens", 0),
-                        completion_tokens=getattr(usage, "completion_tokens", 0),
+                        prompt_tokens=self._extract_prompt_tokens(usage),
+                        completion_tokens=self._extract_completion_tokens(usage),
                         total_tokens=getattr(usage, "total_tokens", 0),
-                        reasoning_tokens=getattr(usage, "reasoning_tokens", 0),
+                        reasoning_tokens=self._extract_reasoning_tokens(usage),
                         cached_tokens=getattr(usage, "cached_tokens", 0),
+                        cache_read_tokens=self._extract_cache_read_tokens(usage),
+                        cache_write_tokens=self._extract_cache_write_tokens(usage),
                     )
 
             # Fallback to estimation if no usage data
@@ -1005,3 +1009,53 @@ class AgentExecutor:
             completion_tokens=estimated_completion_tokens,
             total_tokens=estimated_prompt_tokens + estimated_completion_tokens,
         )
+
+    @staticmethod
+    def _extract_prompt_tokens(usage_source) -> int:
+        return (
+            AgentExecutor._get_usage_value(usage_source, "prompt_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "input_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "total_input_tokens")
+            or 0
+        )
+
+    @staticmethod
+    def _extract_completion_tokens(usage_source) -> int:
+        return (
+            AgentExecutor._get_usage_value(usage_source, "completion_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "output_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "total_output_tokens")
+            or 0
+        )
+
+    @staticmethod
+    def _extract_reasoning_tokens(usage_source) -> int:
+        return (
+            AgentExecutor._get_usage_value(usage_source, "reasoning_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "thinking_tokens")
+            or 0
+        )
+
+    @staticmethod
+    def _extract_cache_read_tokens(usage_source) -> int:
+        return (
+            AgentExecutor._get_usage_value(usage_source, "cache_read_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "cache_read_input_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "prompt_cache_hit_tokens")
+            or 0
+        )
+
+    @staticmethod
+    def _extract_cache_write_tokens(usage_source) -> int:
+        return (
+            AgentExecutor._get_usage_value(usage_source, "cache_write_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "cache_creation_input_tokens")
+            or AgentExecutor._get_usage_value(usage_source, "prompt_cache_miss_tokens")
+            or 0
+        )
+
+    @staticmethod
+    def _get_usage_value(usage_source, attribute: str) -> int:
+        if isinstance(usage_source, dict):
+            return int(usage_source.get(attribute, 0) or 0)
+        return int(getattr(usage_source, attribute, 0) or 0)

--- a/tests/test_agent_executor_token_usage.py
+++ b/tests/test_agent_executor_token_usage.py
@@ -1,0 +1,51 @@
+import types
+
+import pytest
+
+from core.infrastructure.orchestration.agent_executor import AgentExecutor
+
+
+@pytest.fixture
+def executor():
+    return AgentExecutor.__new__(AgentExecutor)
+
+
+def test_extract_token_usage_handles_dict_with_cache_fields(executor):
+    response = types.SimpleNamespace(
+        content="ok",
+        usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 25,
+            "cache_read_input_tokens": 75,
+        },
+    )
+
+    usage = executor._extract_token_usage(response)
+
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 50
+    assert usage.cache_write_tokens == 25
+    assert usage.cache_read_tokens == 75
+    assert usage.cached_tokens == 75
+    assert usage.total_tokens == 225  # prompt + completion + cache read
+
+
+def test_extract_token_usage_handles_object_usage(executor):
+    usage_obj = types.SimpleNamespace(
+        prompt_tokens=80,
+        completion_tokens=40,
+        reasoning_tokens=20,
+        cache_read_tokens=60,
+        cache_write_tokens=10,
+    )
+    response = types.SimpleNamespace(content="ok", usage=usage_obj)
+
+    usage = executor._extract_token_usage(response)
+
+    assert usage.prompt_tokens == 80
+    assert usage.completion_tokens == 40
+    assert usage.reasoning_tokens == 20
+    assert usage.cache_read_tokens == 60
+    assert usage.cache_write_tokens == 10
+    assert usage.total_tokens == 200

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -1,0 +1,110 @@
+import pytest
+
+from core.infrastructure.logging.cost_calculator import CostCalculator, TokenUsage
+
+
+@pytest.fixture()
+def calculator():
+    return CostCalculator()
+
+
+def test_openai_gpt4o_cost_breakdown(calculator):
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=1000)
+
+    breakdown = calculator.calculate_cost("openai", "gpt-4o", usage)
+
+    assert breakdown.prompt_cost == pytest.approx(0.0025)
+    assert breakdown.completion_cost == pytest.approx(0.01)
+    assert breakdown.total_cost == pytest.approx(0.0125)
+
+
+def test_reasoning_tokens_are_included(calculator):
+    usage = TokenUsage(
+        prompt_tokens=500,
+        completion_tokens=250,
+        reasoning_tokens=500,
+    )
+
+    breakdown = calculator.calculate_cost("openai", "o1-mini", usage)
+
+    assert breakdown.prompt_cost == pytest.approx(0.0015)
+    assert breakdown.completion_cost == pytest.approx(0.003)
+    assert breakdown.reasoning_cost == pytest.approx(0.006)
+    assert breakdown.total_cost == pytest.approx(0.0105)
+
+
+def test_cached_tokens_implicit_from_usage(calculator):
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=0,
+        cached_tokens=2000,
+    )
+
+    breakdown = calculator.calculate_cost(
+        "anthropic", "claude-3-5-haiku-20241022", usage
+    )
+
+    assert breakdown.prompt_cost == pytest.approx(0.00080)
+    assert breakdown.cache_cost == pytest.approx(0.00016)
+    assert breakdown.total_cost == pytest.approx(0.00096)
+
+
+def test_cached_tokens_explicit_override(calculator):
+    usage = TokenUsage(prompt_tokens=0, completion_tokens=0, cached_tokens=0)
+
+    breakdown = calculator.calculate_cost(
+        "anthropic", "claude-3-5-haiku-20241022", usage, cached_tokens=1000
+    )
+
+    assert breakdown.cache_cost == pytest.approx(0.00008)
+    assert breakdown.total_cost == pytest.approx(0.00008)
+
+
+def test_unknown_provider_falls_back_to_average(calculator):
+    usage = TokenUsage(prompt_tokens=500, completion_tokens=500)
+
+    breakdown = calculator.calculate_cost("unknown", "model", usage)
+
+    assert breakdown.prompt_cost == pytest.approx(0.001)
+    assert breakdown.completion_cost == pytest.approx(0.003)
+    assert breakdown.total_cost == pytest.approx(0.004)
+
+
+def test_cache_write_cost_is_accounted(calculator):
+    usage = TokenUsage(cache_write_tokens=1000)
+
+    breakdown = calculator.calculate_cost(
+        "anthropic", "claude-3-5-haiku-20241022", usage
+    )
+
+    # Write-only cost should be billed using cache_write rate (0.0010 per 1k tokens)
+    assert breakdown.cache_cost == pytest.approx(0.0010)
+    assert breakdown.total_cost == pytest.approx(0.0010)
+
+
+def test_cache_read_and_write_combined(calculator):
+    usage = TokenUsage(cache_read_tokens=2000, cache_write_tokens=1000)
+
+    breakdown = calculator.calculate_cost(
+        "anthropic", "claude-3-7-sonnet-20250219", usage
+    )
+
+    expected_cache_cost = (2000 / 1000) * 0.00030 + (1000 / 1000) * 0.00375
+    assert breakdown.cache_cost == pytest.approx(expected_cache_cost)
+    assert breakdown.total_cost == pytest.approx(expected_cache_cost)
+
+
+def test_token_usage_total_includes_cache_reads():
+    usage = TokenUsage(cache_read_tokens=1500)
+
+    assert usage.total_tokens == 1500
+
+
+def test_model_alias_resolution(calculator):
+    usage = TokenUsage(prompt_tokens=1000)
+
+    breakdown = calculator.calculate_cost(
+        "anthropic", "claude-3-7-sonnet-20250219-latest", usage
+    )
+
+    assert breakdown.prompt_cost == pytest.approx(0.003)


### PR DESCRIPTION
## Summary
- extend token usage tracking to capture cache write/read tokens and normalize totals for future workflows
- normalize model pricing lookups to tolerate versioned names and include caching write charges in the cost calculator
- harden agent executor token usage parsing and expand unit tests for caching and alias scenarios

## Testing
- pytest tests/test_cost_calculator.py tests/test_agent_executor_token_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ac94e120832792e86b82be91acf8